### PR TITLE
Add links to github profies

### DIFF
--- a/public/about_us/index.html
+++ b/public/about_us/index.html
@@ -154,7 +154,7 @@
               <div class="team-content__item__logos">
 
                 <div class="team-content__item__logos__item">
-                  <a>
+                  <a href="https://github.com/andrewgordstewart">
                     <img src="../assets/people/andrew.png"></img>
                   </a>
                   <ul class="member-list">
@@ -163,7 +163,7 @@
                 </div>
 
                 <div class="team-content__item__logos__item">
-                  <a>
+                  <a href="https://github.com/geoknee">
                     <img src="../assets/people/george.png"></img>
                   </a>
                   <ul class="member-list">
@@ -172,7 +172,7 @@
                 </div>
 
                 <div class="team-content__item__logos__item">
-                  <a>
+                  <a href="https://github.com/kerzhner">
                     <img src="../assets/people/mike.png"></img>
                   </a>
                   <ul class="member-list">
@@ -181,7 +181,7 @@
                 </div>
 
                 <div class="team-content__item__logos__item">
-                  <a>
+                  <a href="https://github.com/lalexgap">
                     <img src="../assets/people/alex.png"></img>
                   </a>
                   <ul class="member-list">
@@ -190,7 +190,7 @@
                 </div>
 
                 <div class="team-content__item__logos__item">
-                  <a>
+                  <a href="https://github.com/nilock">
                     <img src="../assets/people/colin.png"></img>
                   </a>
                   <ul class="member-list">


### PR DESCRIPTION
... minimal github web-ui implementation to remove annoying non-href anchor elements.

Future:
- expand <a> tag to include people's names
- include links to Tom & Connie