### PR TITLE
add links for Tom & Connie

### DIFF
--- a/public/about_us/index.html
+++ b/public/about_us/index.html
@@ -203,8 +203,8 @@
               <div class="team-content__item__contributors">
                 <h3 class="team-content__item__contributors__title">Alumni & Part-Time Contributors</h3>
                 <ul class="team-content__item__contributors__names">
-                  <li>Tom Close</li>
-                  <li>Connie Wong</li>
+                  <a href="https://github.com/tomclose"><li>Tom Close</li></a>
+                  <a href="https://github.com/wunnaii"><li>Connie Wong</li></a>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
these links wrap the `li` items, which
- prevents the text from being decorated as a link
- enlarges the clickable area

... both of which I think we want. Link text decoration is not "useful" outside of, eg, body text, and it is distracting (calls too much attention) in this case.